### PR TITLE
Fixed TypeError, added custom argument to specify no of nfts to "steal"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # NFT Heist
-Time to funge some tokens! Well not really, but this tool will scrape up to 50 NFTs from a provided user.
+Time to steal some jpgs, this tool will scrape up useless NFTs from any provided opensea user.
 
 ## Disclaimer
-This was purely made for informational purposes, and is not intended to be used for any malicious purposes. The creator of this tool (Spinfal) is not responsible for any misuse or harm that this tool may cause. You are responsible for your own actions and not using common sense is not a valid excuse. For whom it may concern; this tool was not made to devalue NFTs in any way. Thank you for reading now here's a cookie to keep you safe 🍪.
+This was purely made for "informational purposes", and is "not" intended to be used for any malicious purposes. The creator of this tool (Spinfal) is "not" responsible for any misuse or harm that this tool may cause. You are responsible for your own actions and not using common sense is not a valid excuse. For whom it may concern; this tool was not made to devalue NFTs in any way. 
+Thank you for reading now here's a cookie to keep you safe 🍪.
 
 ## Requirements
 - Node.js 15 or higher

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ node . <username>
 ## Note: By default it will download 50 nfts to change that add argument at end
 ```
 node . <username> no_of_downloads 
-
+```
 ## Why aren't some users working?
 To be honest; I don't know. I don't know much about OpenSea or NFTs, all I know is if the url looks like this: `https://opensea.io/collection/<username>` then it will work. Otherwise, it will not. But you can still try it.
 

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ npm i
 node . <username>
 ```
 
+## Note: By default it will download 50 nfts to change that add argument at end
+```
+node . <username> no_of_downloads 
+
 ## Why aren't some users working?
 To be honest; I don't know. I don't know much about OpenSea or NFTs, all I know is if the url looks like this: `https://opensea.io/collection/<username>` then it will work. Otherwise, it will not. But you can still try it.
 
-## License
-MIT License (c) 2022 Spinfal
-
-###### made by spin -- https://spin.rip/

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ fetch(`https://api.opensea.io/api/v1/assets?collection=${Self_Args[0]}&format=js
     if (json?.assets < 1) return console.error('The provided user has no assets in their collection to scrape.');
     console.log('User has assets in collection. Scraping...\n')
     json.assets.forEach(asset => {
-        if (asset.image_url.length > 0) {
+        //if (asset.image_url.length > 0) {
+        if (asset && asset.image_url && asset.image_url.length > 0) {
             fungeTheToken({
                 url: asset.image_url,
                 dest: `../../${path}/`

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ fetch(`https://api.opensea.io/api/v1/assets?collection=${Self_Args[0]}&format=js
     console.log('User has assets in collection. Scraping...\n')
     json.assets.forEach(asset => {
         //if (asset.image_url.length > 0) {
-	if (asset && asset.image_url && asset.image_url.length > 0) {
+        if (asset && asset.image_url && asset.image_url.length > 0) {
             fungeTheToken({
                 url: asset.image_url,
                 dest: `../../${path}/`

--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ if (!Self_Args.length) {
 
 const path = `./funged/${Self_Args[0]}/`;
 if (!fs.existsSync(path)) fs.mkdirSync(path);
-
-fetch(`https://api.opensea.io/api/v1/assets?collection=${Self_Args[0]}&format=json&limit=50`, {
+const limit = Self_Args[1] || 50;
+fetch(`https://api.opensea.io/api/v1/assets?collection=${Self_Args[0]}&format=json&limit=${limit}`, {
     headers: {
         'X-Forwarded': '127.0.0.1',
         'User-Agent': 'Mozilla/5.0',
@@ -26,7 +26,7 @@ fetch(`https://api.opensea.io/api/v1/assets?collection=${Self_Args[0]}&format=js
     console.log('User has assets in collection. Scraping...\n')
     json.assets.forEach(asset => {
         //if (asset.image_url.length > 0) {
-        if (asset && asset.image_url && asset.image_url.length > 0) {
+	if (asset && asset.image_url && asset.image_url.length > 0) {
             fungeTheToken({
                 url: asset.image_url,
                 dest: `../../${path}/`


### PR DESCRIPTION
 if (asset.image_url.length > 0) {
                            ^

TypeError: Cannot read properties of null (reading 'length')
    at file:///F:/My%20NFT%20Heist/nft-heist/index.js:28:29
    at Array.forEach (<anonymous>)
    at file:///F:/My%20NFT%20Heist/nft-heist/index.js:27:17
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)